### PR TITLE
Support impersonate similar to capture when transferring authentication to another Thread.

### DIFF
--- a/src/main/java/se/repos/authproxy/transfer/AuthproxyTrustedTransfer.java
+++ b/src/main/java/se/repos/authproxy/transfer/AuthproxyTrustedTransfer.java
@@ -30,6 +30,12 @@ import se.repos.authproxy.ReposCurrentUser;
 public interface AuthproxyTrustedTransfer {
 
 	/**
+	 * Impersonates a username, for next {@link #spread()}.
+	 * Feasible only when backend services do not verify the password.
+	 */
+	void impersonate(String username);
+	
+	/**
 	 * Saves, for next {@link #spread()}, credentials from this particular moment.
 	 */
 	void capture();

--- a/src/main/java/se/repos/authproxy/transfer/AuthproxyTrustedTransferInstanceShare.java
+++ b/src/main/java/se/repos/authproxy/transfer/AuthproxyTrustedTransferInstanceShare.java
@@ -47,6 +47,16 @@ public class AuthproxyTrustedTransferInstanceShare implements
 		this.spreadMethod = TransferMethodFactory.get(currentUser);
 	}
 	
+	//@Override
+	public void impersonate(String username) {
+		if (captured) {
+			throw new IllegalStateException("Can not continue because authentication has already been captured/impersonated but not transferred");
+		}
+		this.u = username;
+		this.p = "";
+		captured = true;
+	}
+	
 	@Override
 	public void capture() {
 		if (captured) {


### PR DESCRIPTION
Related to moving towards not validating passwords for internal requests which enables impersonation in privileged code.

Implemented by generalizing the capture / spread concept.